### PR TITLE
Fix "Address Already in Use" Errors on Back-end

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2906,6 +2906,12 @@
         "pump": "^3.0.0"
       }
     },
+    "get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha1-dKILqKSr7OWuGZrQPyvMaP38m6U=",
+      "dev": true
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -5148,6 +5154,16 @@
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
       "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
     },
+    "kill-port": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-1.6.0.tgz",
+      "integrity": "sha512-gwHRBZ3OLBcupsOJZlIt2Xvf6QqFH3lfdpGnmonXJnJrqq819UXtItGEU1rCMXHK6sXFlxdpkw8ka56rtWw/eQ==",
+      "dev": true,
+      "requires": {
+        "get-them-args": "^1.3.1",
+        "shell-exec": "^1.0.2"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6566,6 +6582,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shell-exec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
+      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==",
       "dev": true
     },
     "shellwords": {

--- a/api/package.json
+++ b/api/package.json
@@ -24,6 +24,14 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.19.0",
-    "jest": "^26.0.1"
+    "jest": "^26.0.1",
+    "kill-port": "^1.6.0"
+  },
+  "nodemonConfig": {
+    "events": {
+      "restart": "kill-port 8000",
+      "crash": "kill-port 8000"
+    },
+    "delay": "1500"
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -29,7 +29,7 @@
   },
   "nodemonConfig": {
     "events": {
-      "restart": "kill-port 8000",
+      "start": "kill-port 8000",
       "crash": "kill-port 8000"
     },
     "delay": "1500"


### PR DESCRIPTION
`nodemon` seems to cause issues like this:

```
Error: listen EADDRINUSE: address already in use :::8000
```

In today's meeting Nan also encountered this error. I don't know if any other people in our group are having this problem, but I did some research online and found this a common one.

Most of the solutions people post for this issue online is something similar to what I suggested: use `lsof` to find the process using port 8000, then `kill -9` it. But doing this over and over again is tedious. So, I looked for a permanent solution and found https://stackoverflow.com/a/59764941.

If you are also having this issue, try adding these commits to your source tree and see if it is mitigated.

One limitation is that it can only scan for port 8000 so far, so if we allow the port to be customized, we might need some other way to resolve this issue.