### PR TITLE
Add Basic Meeting Features to the Back-end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ dist: bionic
 jobs:
   include:
     - name: "api"
+      services:
+        - docker
+      before_script:
+      - docker run -d -p 27017:27017 --rm mongo
+      - echo "USE_LOCAL_DB=true" >> api/.env
     - name: "frontend"
 
 install: npm ci --prefix ${TRAVIS_JOB_NAME}

--- a/api/__tests__/example.test.js
+++ b/api/__tests__/example.test.js
@@ -1,3 +1,0 @@
-it('works', () => {
-  expect(1 + 1).toBe(2);
-});

--- a/api/__tests__/ignored/constants.js
+++ b/api/__tests__/ignored/constants.js
@@ -1,0 +1,10 @@
+module.exports = Object.freeze({
+  /*
+   * The URI to LetsMeet API in a test
+   */
+  API_URI: 'http://localhost:8000/lm',
+  /*
+   * An ObjectId for testing any object not in the database
+   */
+  FAKE_OBJECT_ID: '1234567890abcdef12345678',
+});

--- a/api/__tests__/ignored/globalSetup.js
+++ b/api/__tests__/ignored/globalSetup.js
@@ -1,0 +1,6 @@
+const kill = require('kill-port');
+
+module.exports = () => {
+  console.log('\nKilling any process that is using the port for the API...');
+  kill(8000);
+};

--- a/api/__tests__/ignored/setup.js
+++ b/api/__tests__/ignored/setup.js
@@ -1,0 +1,5 @@
+const server = require('../../server');
+
+afterAll(() => {
+  server.close();
+});

--- a/api/__tests__/meeting.test.js
+++ b/api/__tests__/meeting.test.js
@@ -1,0 +1,248 @@
+// Tests for the /meeting and /meetings endpoints
+
+const constants = require('./ignored/constants');
+const axios = require('axios').default;
+const mongoose = require('mongoose');
+
+describe('/meeting/delete/:meetingId', () => {
+  it('gets null data when invalid meeting is given', async () => {
+    const response = await axios.delete(
+      constants.API_URI + '/meeting/delete/' + constants.FAKE_OBJECT_ID
+    );
+    expect(response.data.data).toBeNull();
+  });
+});
+
+describe('/meetings', () => {
+  it('creates a meeting with all arguments correctly', async () => {
+    const author = mongoose.Types.ObjectId().toString();
+    const name = 'Test';
+    const groupId = mongoose.Types.ObjectId().toString();
+    const startTime = '2020-05-19T13:30:00.000Z';
+    const endTime = '2020-05-19T17:30:00.000Z';
+    const confirmed = true;
+
+    let data;
+    try {
+      const response = await axios.post(constants.API_URI + '/meetings', {
+        author: author,
+        name: name,
+        groupId: groupId,
+        startTime: startTime,
+        endTime: endTime,
+        confirmed: confirmed,
+      });
+      data = response.data.data;
+
+      expect(data.author).toBe(author);
+      expect(data.name).toBe(name);
+      expect(data.groupID).toBe(groupId);
+      expect(data.startTime).toBe(startTime);
+      expect(data.endTime).toBe(endTime);
+      expect(data.confirmed).toBe(confirmed);
+    } finally {
+      // Tear down
+      await axios.delete(
+        constants.API_URI + '/meeting/delete/' + data._id
+      );
+    }
+  });
+
+  it('creates a meeting with only required arguments correctly', async () => {
+    const author = mongoose.Types.ObjectId().toString();
+    const name = 'Test';
+    const groupId = mongoose.Types.ObjectId().toString();
+    const startTime = '2020-05-19T13:30:00.000Z';
+    const endTime = '2020-05-19T17:30:00.000Z';
+
+    let data;
+    try {
+      const response = await axios.post(constants.API_URI + '/meetings', {
+        author: author,
+        name: name,
+        groupId: groupId,
+        startTime: startTime,
+        endTime: endTime,
+      });
+      data = response.data.data;
+
+      expect(data.author).toBe(author);
+      expect(data.name).toBe(name);
+      expect(data.groupID).toBe(groupId);
+      expect(data.startTime).toBe(startTime);
+      expect(data.endTime).toBe(endTime);
+      expect(data.confirmed).toBe(false);
+    } finally {
+      // Tear down
+      await axios.delete(
+        constants.API_URI + '/meeting/delete/' + data._id
+      );
+    }
+  });
+});
+
+describe('/meeting/:meetingId', () => {
+  it('gets null data when invalid meeting is given', async () => {
+    const response = await axios.get(
+      constants.API_URI + '/meeting/' + constants.FAKE_OBJECT_ID
+    );
+    expect(response.data.data).toBeNull();
+  });
+
+  it('gets a meeting with correct information', async () => {
+    const author = mongoose.Types.ObjectId().toString();
+    const name = 'Test';
+    const groupId = mongoose.Types.ObjectId().toString();
+    const startTime = '2020-05-19T13:30:00.000Z';
+    const endTime = '2020-05-19T17:30:00.000Z';
+    const confirmed = true;
+
+    let meeting, data;
+    try {
+      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
+        author: author,
+        name: name,
+        groupId: groupId,
+        startTime: startTime,
+        endTime: endTime,
+        confirmed: confirmed,
+      });
+      meeting = meetingRes.data.data;
+
+      const response = await axios.get(
+        constants.API_URI + '/meeting/' + meeting._id
+      );
+      data = response.data.data;
+
+      expect(data.author).toBe(author);
+      expect(data.name).toBe(name);
+      expect(data.groupID).toBe(groupId);
+      expect(data.startTime).toBe(startTime);
+      expect(data.endTime).toBe(endTime);
+      expect(data.confirmed).toBe(confirmed);
+    } finally {
+      // Tear down
+      await axios.delete(
+        constants.API_URI + '/meeting/delete/' + meeting._id
+      );
+    }
+  });
+});
+
+describe('/meeting/confirm/:meetingId', () => {
+  it('gets 404 status when invalid meeting is given', async () => {
+    const response = await axios.post(
+      constants.API_URI + '/meeting/confirm/' + constants.FAKE_OBJECT_ID
+    );
+    expect(response.data.status).toBe(404);
+  });
+
+  it('gets 409 status when confirming a confirmed meeting', async () => {
+    let meeting, data;
+    try {
+      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
+        author: mongoose.Types.ObjectId().toString(),
+        name: 'Test',
+        groupId: mongoose.Types.ObjectId().toString(),
+        startTime: '2020-05-19T13:30:00.000Z',
+        endTime: '2020-05-19T17:30:00.000Z',
+        confirmed: true,
+      });
+      meeting = meetingRes.data.data;
+
+      const response = await axios.post(
+        constants.API_URI + '/meeting/confirm/' + meeting._id
+      );
+      expect(response.data.status).toBe(409);
+    } finally {
+      // Tear down
+      await axios.delete(
+        constants.API_URI + '/meeting/delete/' + meeting._id
+      );
+    }
+  });
+
+  it('confirms an unconfirmed meeting successfully', async () => {
+    let meeting, data;
+    try {
+      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
+        author: mongoose.Types.ObjectId().toString(),
+        name: 'Test',
+        groupId: mongoose.Types.ObjectId().toString(),
+        startTime: '2020-05-19T13:30:00.000Z',
+        endTime: '2020-05-19T17:30:00.000Z',
+        confirmed: false,
+      });
+      meeting = meetingRes.data.data;
+
+      const response = await axios.post(
+        constants.API_URI + '/meeting/confirm/' + meeting._id
+      );
+      expect(response.data.data.confirmed).toBe(true);
+    } finally {
+      // Tear down
+      await axios.delete(
+        constants.API_URI + '/meeting/delete/' + meeting._id
+      );
+    }
+  });
+});
+
+describe('/meeting/unconfirm/:meetingId', () => {
+  it('gets 404 status when invalid meeting is given', async () => {
+    const response = await axios.post(
+      constants.API_URI + '/meeting/unconfirm/' + constants.FAKE_OBJECT_ID
+    );
+    expect(response.data.status).toBe(404);
+  });
+
+  it('gets 409 status when unconfirming a not confirmed meeting', async () => {
+    let meeting, data;
+    try {
+      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
+        author: mongoose.Types.ObjectId().toString(),
+        name: 'Test',
+        groupId: mongoose.Types.ObjectId().toString(),
+        startTime: '2020-05-19T13:30:00.000Z',
+        endTime: '2020-05-19T17:30:00.000Z',
+        confirmed: false,
+      });
+      meeting = meetingRes.data.data;
+
+      const response = await axios.post(
+        constants.API_URI + '/meeting/unconfirm/' + meeting._id
+      );
+      expect(response.data.status).toBe(409);
+    } finally {
+      // Tear down
+      await axios.delete(
+        constants.API_URI + '/meeting/delete/' + meeting._id
+      );
+    }
+  });
+
+  it('unconfirms a confirmed meeting successfully', async () => {
+    let meeting, data;
+    try {
+      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
+        author: mongoose.Types.ObjectId().toString(),
+        name: 'Test',
+        groupId: mongoose.Types.ObjectId().toString(),
+        startTime: '2020-05-19T13:30:00.000Z',
+        endTime: '2020-05-19T17:30:00.000Z',
+        confirmed: true,
+      });
+      meeting = meetingRes.data.data;
+
+      const response = await axios.post(
+        constants.API_URI + '/meeting/unconfirm/' + meeting._id
+      );
+      expect(response.data.data.confirmed).toBe(false);
+    } finally {
+      // Tear down
+      await axios.delete(
+        constants.API_URI + '/meeting/delete/' + meeting._id
+      );
+    }
+  });
+});

--- a/api/__tests__/user.test.js
+++ b/api/__tests__/user.test.js
@@ -1,0 +1,69 @@
+// Tests for the /user and /users endpoints
+
+const constants = require('./ignored/constants');
+const axios = require('axios').default;
+
+describe('/user/meetings/:userId', () => {
+  it('gets 404 status when invalid user is given', async () => {
+    const response = await axios.get(
+      constants.API_URI + '/user/meetings/' + constants.FAKE_OBJECT_ID
+    );
+    expect(response.data.status).toBe(404);
+  });
+});
+
+describe('/user/addMeeting', () => {
+  it('removes a meeting from a user', async () => {
+    let userId;
+    try {
+      const meetingId = constants.FAKE_OBJECT_ID
+
+      const userRes = await axios.post(constants.API_URI + '/users', {
+        username: 'testuser',
+        email: 'test@example.com',
+        phone: '123456789',
+        password: 'DontUseThisPassword',
+        displayName: 'TestUser',
+      });
+      userId = userRes.data.data._id;
+      await axios.post(constants.API_URI + '/user/addMeeting', {
+        userId: userId,
+        meetingId: meetingId,
+      });
+      const response = await axios.get(constants.API_URI + '/user/' + userId);
+      expect(response.data.data.meetings).toContain(meetingId);
+    } finally {
+      // TODO: tear down with REST API when user deletion endpoint is available
+    }
+  });
+});
+
+describe('/user/removeMeeting', () => {
+  it('adds a meeting to a user', async () => {
+    let userId;
+    try {
+      const meetingId = constants.FAKE_OBJECT_ID
+
+      const userRes = await axios.post(constants.API_URI + '/users', {
+        username: 'testuser',
+        email: 'test@example.com',
+        phone: '123456789',
+        password: 'DontUseThisPassword',
+        displayName: 'TestUser',
+      });
+      userId = userRes.data.data._id;
+      await axios.post(constants.API_URI + '/user/addMeeting', {
+        userId: userId,
+        meetingId: meetingId,
+      });
+      await axios.post(constants.API_URI + '/user/removeMeeting', {
+        userId: userId,
+        meetingId: meetingId,
+      });
+      const response = await axios.get(constants.API_URI + '/user/' + userId);
+      expect(response.data.data.meetings).toHaveLength(0);
+    } finally {
+      // TODO: tear down with REST API when user deletion endpoint is available
+    }
+  });
+});

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1307,6 +1307,15 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "axobject-query": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
@@ -2817,6 +2826,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2906,6 +2906,12 @@
         "pump": "^3.0.0"
       }
     },
+    "get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha1-dKILqKSr7OWuGZrQPyvMaP38m6U=",
+      "dev": true
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -5148,6 +5154,16 @@
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
       "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
     },
+    "kill-port": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-1.6.0.tgz",
+      "integrity": "sha512-gwHRBZ3OLBcupsOJZlIt2Xvf6QqFH3lfdpGnmonXJnJrqq819UXtItGEU1rCMXHK6sXFlxdpkw8ka56rtWw/eQ==",
+      "dev": true,
+      "requires": {
+        "get-them-args": "^1.3.1",
+        "shell-exec": "^1.0.2"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6566,6 +6582,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shell-exec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
+      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==",
       "dev": true
     },
     "shellwords": {

--- a/api/package.json
+++ b/api/package.json
@@ -24,6 +24,14 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.19.0",
-    "jest": "^26.0.1"
+    "jest": "^26.0.1",
+    "kill-port": "^1.6.0"
+  },
+  "nodemonConfig": {
+    "events": {
+      "start": "kill-port 8000",
+      "crash": "kill-port 8000"
+    },
+    "delay": "1500"
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --forceExit --runInBand",
     "start": "nodemon server.js"
   },
   "keywords": [],
@@ -18,6 +18,7 @@
     "mongoose": "^5.9.10"
   },
   "devDependencies": {
+    "axios": "^0.19.2",
     "babel-eslint": "^10.1.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.1.0",
@@ -26,6 +27,16 @@
     "eslint-plugin-react": "^7.19.0",
     "jest": "^26.0.1",
     "kill-port": "^1.6.0"
+  },
+  "jest": {
+    "globalSetup": "./__tests__/ignored/globalSetup",
+    "setupFilesAfterEnv": [
+      "./__tests__/ignored/setup.js"
+    ],
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "__tests__/ignored"
+    ]
   },
   "nodemonConfig": {
     "events": {

--- a/api/server.js
+++ b/api/server.js
@@ -22,24 +22,25 @@ app.use(
 app.use(bodyParser.json());
 dotenv.config();
 
-// Connect to Mongoose Cluster and set connection variable
-mongoose.connect(
-  "mongodb+srv://" +
+let dbUri;
+if (process.env.USE_LOCAL_DB) {
+  console.log("Connecting to local MongoDB database");
+  dbUri = "mongodb://localhost/LetsMeet";
+} else {
+  console.log("Connecting to MongoDB Cluster");
+  dbUri = "mongodb+srv://" +
     process.env.DB_USERNAME +
     ":" +
     process.env.DB_PW +
-    "@cluster0-kdglj.mongodb.net/LetsMeet?retryWrites=true&w=majority",
-  {
+    "@cluster0-kdglj.mongodb.net/LetsMeet?retryWrites=true&w=majority";
+}
+
+// Connect to the selected Mongoose instance and set connection variable
+mongoose.connect(dbUri, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
   }
 );
-
-// //Connect to MongoDB Local Instance
-// mongoose.connect("mongodb://localhost/LetsMeet", {
-//   useNewUrlParser: true,
-//   useUnifiedTopology: true,
-// });
 
 var db = mongoose.connection;
 

--- a/api/server.js
+++ b/api/server.js
@@ -58,6 +58,8 @@ app.get("/", cors(), (req, res) => res.send("LetsMeet API"));
 // Use Api routes in the App
 app.use("/lm", cors(), apiRoutes);
 // Launch app to listen to specified port
-app.listen(port, function () {
+var server = app.listen(port, function () {
   console.log("Running LetsMeet API @ localhost:" + port);
 });
+
+module.exports = server

--- a/api/server.js
+++ b/api/server.js
@@ -23,7 +23,7 @@ app.use(bodyParser.json());
 dotenv.config();
 
 let dbUri;
-if (process.env.USE_LOCAL_DB) {
+if (process.env.USE_LOCAL_DB === 'true') {
   console.log("Connecting to local MongoDB database");
   dbUri = "mongodb://localhost/LetsMeet";
 } else {

--- a/api/server/api-routes.js
+++ b/api/server/api-routes.js
@@ -11,6 +11,9 @@ router.get("/", function (req, res) {
 // Import user controller
 let userController = require("./controllers/userController");
 let groupController = require("./controllers/groupController")
+// Import meeting controller
+var meetingController = require("./controllers/meetingController");
+
 // User routes
 
 // Create user
@@ -53,6 +56,20 @@ router
   .route('/user/removeGroup')
   .post(userController.removeGroup)
 
+// Get user meetings
+router
+  .route('/user/meetings/:userId')
+  .get(userController.userMeetings);
+
+// Add meeting to the list of user's meetings
+router
+  .route('/user/addMeeting')
+  .post(userController.addMeeting);
+
+// Remove meeting from the list of user's meetings
+router
+  .route('/user/removeMeeting')
+  .post(userController.removeMeeting);
 
 
   //// Group paths ////
@@ -117,6 +134,36 @@ router
 router
   .route('/group/removeMeetingRequest')
   .post(groupController.removeMeetingRequest)
+
+
+  //// Meeting paths ////
+
+
+// Create a meeting
+router
+  .route('/meetings')
+  .post(meetingController.create);
+
+// Delete a meeting
+router
+  .route('/meeting/delete/:meetingId')
+  .delete(meetingController.delete);
+
+// Get all the details about a meeting
+router
+  .route('/meeting/:meetingId')
+  .get(meetingController.view);
+
+// Confirm a meeting
+router
+  .route('/meeting/confirm/:meetingId')
+  .post(meetingController.confirm);
+
+// Unconfirm a meeting
+router
+  .route('/meeting/unconfirm/:meetingId')
+  .post(meetingController.unconfirm);
+
 
 // Export API routes
 module.exports = router;

--- a/api/server/controllers/meetingController.js
+++ b/api/server/controllers/meetingController.js
@@ -1,0 +1,210 @@
+// meetingController.js
+// Import meeting model
+Meeting = require("../models/meetingModel")
+// Import dependent models
+User = require("../models/userModel")
+
+/*
+ * Creates a new meeting.
+ *
+ * Required body parameters:
+ *  author: ObjectId - the meeting's author
+ *  name: String - the meeting's name
+ *  groupId: ObjectId - the ID of the group that holds the meeting
+ *  startTime: Date - the start time of the meeting
+ *  endTime: Date - the end time of the meeting
+ *
+ * Optional body parameters:
+ *  confirmed: Boolean (default: false) - whether the meeting is confirmed
+ *
+ * Returns:
+ *  500 if an internal server error occurs
+ *  The created meeting if the operation was successful
+ */
+exports.create = function (req, res) {
+  const meeting = new Meeting();
+  meeting.author = req.body.author;
+  meeting.name = req.body.name;
+  meeting.groupID = req.body.groupId;
+  meeting.startTime = req.body.startTime;
+  meeting.endTime = req.body.endTime;
+  meeting.confirmed = req.body.confirmed ? req.body.confirmed : false;
+  meeting.save(function (err) {
+    if (err) {
+      res.json({
+        status: 500,
+        errorMessage: err.message,
+        errorName: err.name,
+      });
+    } else {
+      res.json({
+        status: res.statusCode,
+        message: "Meeting created successfully",
+        data: meeting,
+      });
+    }
+  });
+};
+
+/*
+ * Deletes a meeting.
+ *
+ * Required query parameters:
+ *  meetingId: ObjectId - the meeting's ID
+ *
+ * Returns:
+ *  500 if an internal server error occurs
+ *  The deleted meeting if the operation was successful
+ */
+exports.delete = function (req, res) {
+  Meeting.findByIdAndRemove(req.params.meetingId, function (err, meeting) {
+    if (err) {
+      res.json({
+        status: 500,
+        errorMessage: err.message,
+        errorName: err.name,
+      });
+    } else {
+      res.json({
+        status: res.statusCode,
+        data: meeting,
+      });
+    }
+  });
+};
+
+/*
+ * Gets all the data about a meeting.
+ *
+ * Required query parameters:
+ *  meetingId: ObjectId - the meeting's ID
+ *
+ * Returns:
+ *  500 if an internal server error occurs
+ *  The meeting's data if the operation was successful
+ */
+exports.view = function (req, res) {
+  Meeting.findById(req.params.meetingId, function (err, meeting) {
+    if (err) {
+      res.json({
+        status: 500,
+        errorMessage: err.message,
+        errorName: err.name,
+      });
+    } else {
+      res.json({
+        status: res.statusCode,
+        data: meeting,
+      });
+    }
+  });
+};
+
+/*
+ * Confirms a meeting.
+ *
+ * Required query parameters:
+ *  meetingId: ObjectId - the meeting's ID
+ *
+ * Returns:
+ *  500 if an internal server error occurs
+ *  404 if the meeting does not exist
+ *  409 if the meeting is already confirmed
+ *  The updated meeting's data if the operation was successful
+ */
+exports.confirm = function (req, res) {
+  updateMeetingConfirmation(req, res, true);
+};
+
+/*
+ * Unconfirms a meeting.
+ *
+ * Required query parameters:
+ *  meetingId: ObjectId - the meeting's ID
+ *
+ * Returns:
+ *  500 if an internal server error occurs
+ *  404 if the meeting does not exist
+ *  409 if the meeting is already not confirmed
+ *  The updated meeting's data if the operation was successful
+ */
+exports.unconfirm = function (req, res) {
+  updateMeetingConfirmation(req, res, false);
+};
+
+/*
+ * Internal helper function
+ *
+ * Updates the confirmation flag for a meeting.
+ *
+ * Function parameters:
+ *  req: the request received from client
+ *  res: the response to be sent to client
+ *  toConfirm - Boolean: 'true' for a confirming operation,
+ *    or 'false for an unconfirming operation
+ *
+ * Required query parameters:
+ *  meetingId: ObjectId - the meeting's ID
+ *
+ * Response will be updated with:
+ *  500 if an internal server error occurs
+ *  404 if the meeting does not exist
+ *  409 if the meeting is already confirmed
+ *  The updated meeting's data if the operation was successful
+ */
+function updateMeetingConfirmation(req, res, toConfirm) {
+  Meeting.findById(req.params.meetingId, function (err, meeting) {
+    if (err) {
+      res.json({
+        status: 500,
+        errorMessage: err.message,
+        errorName: err.name,
+      });
+    } else if (meeting) {
+      const confirmed = meeting.confirmed;
+      if (confirmed === toConfirm) {
+        if (toConfirm) {
+          res.json({
+            status: 409,
+            message: "Meeting already confirmed",
+          });
+        } else {
+          res.json({
+            status: 409,
+            message: "Meeting already not confirmed",
+          });
+        }
+      } else {
+        meeting.confirmed = toConfirm;
+        meeting.save(function (err) {
+          if (err) {
+            res.json({
+              status: 500,
+              errorMessage: err.message,
+              errorName: err.name,
+            });
+          } else {
+            if (toConfirm) {
+              res.json({
+                status: res.statusCode,
+                message: "Meeting confirmed successfully",
+                data: meeting,
+              });
+            } else {
+              res.json({
+                status: res.statusCode,
+                message: "Meeting unconfirmed successfully",
+                data: meeting,
+              });
+            }
+          }
+        });
+      }
+    } else {
+      res.json({
+        status: 404,
+        message: "Meeting not exist",
+      });
+    }
+  });
+}

--- a/api/server/controllers/userController.js
+++ b/api/server/controllers/userController.js
@@ -220,3 +220,79 @@ exports.removeGroup = function(req, res) {
     }
   })
 }
+
+// Gets meetings for a particular user
+exports.userMeetings = function(req, res) {
+  User.findById(req.params.userId, function (err, user) {
+    if (err) {
+      res.json({
+        status: 500,
+        errorMessage: err.message,
+        errorName: err.name,
+      });
+    } else if (user) {
+      res.json({
+        status: 200,
+        message: "User's meetings",
+        data: user.meetings,
+      });
+    } else {
+      res.json({
+        status: 404,
+        message: "User not exist",
+      });
+    }
+  });
+}
+
+// Receives an userId and a meetingId as input
+// Adds the meetingId to the user's meetings list
+exports.addMeeting = function(req, res) {
+  User.update(
+    {_id: req.body.userId},
+    {
+      $push: {meetings: req.body.meetingId}
+    },
+    function(err, data) {
+      if (err) {
+        res.json({
+          status: 500,
+          errorMessage: err.message,
+          errorName: err.name,
+        });
+      } else {
+        res.json({
+          status: res.statusCode,
+          message: "Meeting successfully added to the user",
+          data: data,
+        });
+      }
+    }
+  );
+}
+
+// Receives an userId and a meetingId as input
+// Removes the meetingId from the user's meetings list
+exports.removeMeeting = function(req, res) {
+  User.update(
+    {_id: req.body.userId},
+    {
+      $pull: {meetings: req.body.meetingId}
+    },
+    function(err, data) {
+      if (err) {
+        res.json({
+          status: 500,
+          errorMessage: err.message,
+          errorName: err.name,
+        });
+      } else {
+        res.json({
+          status: res.statusCode,
+          message: "Meeting successfully deleted from the user",
+          data: data,
+        });
+      }
+    }
+  );
+}

--- a/api/server/models/meetingModel.js
+++ b/api/server/models/meetingModel.js
@@ -1,12 +1,12 @@
 var mongoose = require("mongoose");
 
-var DayTime = require("./dayTimeModel");
-
 var meetingSchema = mongoose.Schema({
   author: mongoose.Types.ObjectId, //UserID
   name: String,
   groupID: mongoose.Types.ObjectId,
-  time: DayTime,
+  startTime: Date,
+  endTime: Date,
+  confirmed: Boolean,
 });
 
 var Meeting = (module.exports = mongoose.model("meeting", meetingSchema));


### PR DESCRIPTION
### Summary

The main purpose of this pull request is to add some endpoints for creating, querying, modifying and deleting meetings to the back-end API (425c0ce). Unit tests are included (5ae19cb). The back-end meeting model is also changed per our discussion in today's Zoom session (c35eb26).

### Side Effects

There are also some side effects that will be introduced to our project after this pull request is merged:
- The fix for the "address already in use" issue originally in pull request #15 will be added by f6bbe05
- `api/server.js` will export the server created with `express().listen()`, as in 1ae0b00; this is necessary for the unit tests to run properly
- The feature of using the local database for the back-end, which was in the `use-local-db` branch, will be merged with 8cfc4a5

I'd like to hear your opinions on these side effects, especially the first two, which haven't been discussed by the whole group yet.

### If You've Pulled This Branch Before...

**If you have checked out the `api/meeting` branch before**, because I've done a rebase to this branch to make the commit history look tidier, **you can't directly pull this branch in your local repo**. Instead, you must do the following:
```sh
$ git fetch
$ git checkout api/meeting
$ git reset --hard origin/api/meeting
```