### PR TITLE
Updates on Meeting-related API Routes

### DIFF
--- a/api/__tests__/meeting.test.js
+++ b/api/__tests__/meeting.test.js
@@ -1,247 +1,180 @@
-// Tests for the /meeting and /meetings endpoints
+// Tests for the /meeting endpoints
 
-const constants = require('./ignored/constants');
-const axios = require('axios').default;
-const mongoose = require('mongoose');
+const constants = require("./ignored/constants");
+const axios = require("axios").default;
+const mongoose = require("mongoose");
 
-describe('/meeting/delete/:meetingId', () => {
-  it('gets null data when invalid meeting is given', async () => {
+describe("DELETE /meeting/:meetingId", () => {
+  it("gets null data when invalid meeting is given", async () => {
     const response = await axios.delete(
-      constants.API_URI + '/meeting/delete/' + constants.FAKE_OBJECT_ID
+      `${constants.API_URI}/meeting/${constants.FAKE_OBJECT_ID}`
     );
-    expect(response.data.data).toBeNull();
+    expect(response.data).toBeNull();
   });
 });
 
-describe('/meetings', () => {
-  it('creates a meeting with all arguments correctly', async () => {
+describe("/meeting/create", () => {
+  it("creates a meeting with all arguments correctly", async () => {
     const author = mongoose.Types.ObjectId().toString();
-    const name = 'Test';
-    const groupId = mongoose.Types.ObjectId().toString();
-    const startTime = '2020-05-19T13:30:00.000Z';
-    const endTime = '2020-05-19T17:30:00.000Z';
+    const name = "Test";
+    const group = mongoose.Types.ObjectId().toString();
+    const start = "2020-05-19T13:30:00.000Z";
+    const end = "2020-05-19T17:30:00.000Z";
     const confirmed = true;
 
     let data;
     try {
-      const response = await axios.post(constants.API_URI + '/meetings', {
-        author: author,
-        name: name,
-        groupId: groupId,
-        startTime: startTime,
-        endTime: endTime,
-        confirmed: confirmed,
-      });
-      data = response.data.data;
+      const response = await axios.post(
+        `${constants.API_URI}/meeting/create`,
+        {
+          author: author,
+          name: name,
+          group: group,
+          start: start,
+          end: end,
+          confirmed: confirmed,
+        }
+      );
+      data = response.data;
 
       expect(data.author).toBe(author);
       expect(data.name).toBe(name);
-      expect(data.groupID).toBe(groupId);
-      expect(data.startTime).toBe(startTime);
-      expect(data.endTime).toBe(endTime);
+      expect(data.group).toBe(group);
+      expect(data.start).toBe(start);
+      expect(data.end).toBe(end);
       expect(data.confirmed).toBe(confirmed);
     } finally {
       // Tear down
       await axios.delete(
-        constants.API_URI + '/meeting/delete/' + data._id
+        `${constants.API_URI}/meeting/${data._id}`
       );
     }
   });
 
-  it('creates a meeting with only required arguments correctly', async () => {
+  it("creates a meeting with only required arguments correctly", async () => {
     const author = mongoose.Types.ObjectId().toString();
-    const name = 'Test';
-    const groupId = mongoose.Types.ObjectId().toString();
-    const startTime = '2020-05-19T13:30:00.000Z';
-    const endTime = '2020-05-19T17:30:00.000Z';
+    const name = "Test";
+    const group = mongoose.Types.ObjectId().toString();
+    const start = "2020-05-19T13:30:00.000Z";
+    const end = "2020-05-19T17:30:00.000Z";
 
     let data;
     try {
-      const response = await axios.post(constants.API_URI + '/meetings', {
-        author: author,
-        name: name,
-        groupId: groupId,
-        startTime: startTime,
-        endTime: endTime,
-      });
-      data = response.data.data;
+      const response = await axios.post(
+        `${constants.API_URI}/meeting/create`,
+        {
+          author: author,
+          name: name,
+          group: group,
+          start: start,
+          end: end,
+        }
+      );
+      data = response.data;
 
       expect(data.author).toBe(author);
       expect(data.name).toBe(name);
-      expect(data.groupID).toBe(groupId);
-      expect(data.startTime).toBe(startTime);
-      expect(data.endTime).toBe(endTime);
+      expect(data.group).toBe(group);
+      expect(data.start).toBe(start);
+      expect(data.end).toBe(end);
       expect(data.confirmed).toBe(false);
     } finally {
       // Tear down
       await axios.delete(
-        constants.API_URI + '/meeting/delete/' + data._id
+        `${constants.API_URI}/meeting/${data._id}`
       );
     }
   });
 });
 
-describe('/meeting/:meetingId', () => {
-  it('gets null data when invalid meeting is given', async () => {
+describe("GET /meeting/:meetingId", () => {
+  it("gets null data when invalid meeting is given", async () => {
     const response = await axios.get(
-      constants.API_URI + '/meeting/' + constants.FAKE_OBJECT_ID
+      `${constants.API_URI}/meeting/${constants.FAKE_OBJECT_ID}`
     );
-    expect(response.data.data).toBeNull();
+    expect(response.data).toBeNull();
   });
 
-  it('gets a meeting with correct information', async () => {
+  it("gets a meeting with correct information", async () => {
     const author = mongoose.Types.ObjectId().toString();
-    const name = 'Test';
-    const groupId = mongoose.Types.ObjectId().toString();
-    const startTime = '2020-05-19T13:30:00.000Z';
-    const endTime = '2020-05-19T17:30:00.000Z';
+    const name = "Test";
+    const group = mongoose.Types.ObjectId().toString();
+    const start = "2020-05-19T13:30:00.000Z";
+    const end = "2020-05-19T17:30:00.000Z";
     const confirmed = true;
 
     let meeting, data;
     try {
-      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
-        author: author,
-        name: name,
-        groupId: groupId,
-        startTime: startTime,
-        endTime: endTime,
-        confirmed: confirmed,
-      });
-      meeting = meetingRes.data.data;
+      const meetingRes = await axios.post(
+        `${constants.API_URI}/meeting/create`,
+        {
+          author: author,
+          name: name,
+          group: group,
+          start: start,
+          end: end,
+          confirmed: confirmed,
+        }
+      );
+      meeting = meetingRes.data;
 
       const response = await axios.get(
-        constants.API_URI + '/meeting/' + meeting._id
+        `${constants.API_URI}/meeting/${meeting._id}`
       );
-      data = response.data.data;
+      data = response.data;
 
       expect(data.author).toBe(author);
       expect(data.name).toBe(name);
-      expect(data.groupID).toBe(groupId);
-      expect(data.startTime).toBe(startTime);
-      expect(data.endTime).toBe(endTime);
+      expect(data.group).toBe(group);
+      expect(data.start).toBe(start);
+      expect(data.end).toBe(end);
       expect(data.confirmed).toBe(confirmed);
     } finally {
       // Tear down
       await axios.delete(
-        constants.API_URI + '/meeting/delete/' + meeting._id
+        `${constants.API_URI}/meeting/${meeting._id}`
       );
     }
   });
 });
 
-describe('/meeting/confirm/:meetingId', () => {
-  it('gets 404 status when invalid meeting is given', async () => {
-    const response = await axios.post(
-      constants.API_URI + '/meeting/confirm/' + constants.FAKE_OBJECT_ID
+describe("PATCH /meeting/:meetingId", () => {
+  it("gets null data when invalid meeting is given", async () => {
+    const response = await axios.patch(
+      `${constants.API_URI}/meeting/${constants.FAKE_OBJECT_ID}`
     );
-    expect(response.data.status).toBe(404);
+    expect(response.data).toBeNull();
   });
 
-  it('gets 409 status when confirming a confirmed meeting', async () => {
-    let meeting, data;
+  it("confirms a meeting", async () => {
+    let meeting;
     try {
-      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
-        author: mongoose.Types.ObjectId().toString(),
-        name: 'Test',
-        groupId: mongoose.Types.ObjectId().toString(),
-        startTime: '2020-05-19T13:30:00.000Z',
-        endTime: '2020-05-19T17:30:00.000Z',
-        confirmed: true,
-      });
-      meeting = meetingRes.data.data;
-
-      const response = await axios.post(
-        constants.API_URI + '/meeting/confirm/' + meeting._id
+      const meetingRes = await axios.post(
+        `${constants.API_URI}/meeting/create`,
+        {
+          author: mongoose.Types.ObjectId().toString(),
+          name: "Test",
+          group: mongoose.Types.ObjectId().toString(),
+          start: "2020-05-19T13:30:00.000Z",
+          end: "2020-05-19T17:30:00.000Z",
+          confirmed: false,
+        }
       );
-      expect(response.data.status).toBe(409);
+      meeting = meetingRes.data;
+      await axios.patch(
+        `${constants.API_URI}/meeting/${meeting._id}`,
+        {
+          confirmed: true,
+        }
+      );
+      const response = await axios.get(
+        `${constants.API_URI}/meeting/${meeting._id}`
+      );
+      expect(response.data.confirmed).toBe(true);
     } finally {
       // Tear down
       await axios.delete(
-        constants.API_URI + '/meeting/delete/' + meeting._id
-      );
-    }
-  });
-
-  it('confirms an unconfirmed meeting successfully', async () => {
-    let meeting, data;
-    try {
-      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
-        author: mongoose.Types.ObjectId().toString(),
-        name: 'Test',
-        groupId: mongoose.Types.ObjectId().toString(),
-        startTime: '2020-05-19T13:30:00.000Z',
-        endTime: '2020-05-19T17:30:00.000Z',
-        confirmed: false,
-      });
-      meeting = meetingRes.data.data;
-
-      const response = await axios.post(
-        constants.API_URI + '/meeting/confirm/' + meeting._id
-      );
-      expect(response.data.data.confirmed).toBe(true);
-    } finally {
-      // Tear down
-      await axios.delete(
-        constants.API_URI + '/meeting/delete/' + meeting._id
-      );
-    }
-  });
-});
-
-describe('/meeting/unconfirm/:meetingId', () => {
-  it('gets 404 status when invalid meeting is given', async () => {
-    const response = await axios.post(
-      constants.API_URI + '/meeting/unconfirm/' + constants.FAKE_OBJECT_ID
-    );
-    expect(response.data.status).toBe(404);
-  });
-
-  it('gets 409 status when unconfirming a not confirmed meeting', async () => {
-    let meeting, data;
-    try {
-      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
-        author: mongoose.Types.ObjectId().toString(),
-        name: 'Test',
-        groupId: mongoose.Types.ObjectId().toString(),
-        startTime: '2020-05-19T13:30:00.000Z',
-        endTime: '2020-05-19T17:30:00.000Z',
-        confirmed: false,
-      });
-      meeting = meetingRes.data.data;
-
-      const response = await axios.post(
-        constants.API_URI + '/meeting/unconfirm/' + meeting._id
-      );
-      expect(response.data.status).toBe(409);
-    } finally {
-      // Tear down
-      await axios.delete(
-        constants.API_URI + '/meeting/delete/' + meeting._id
-      );
-    }
-  });
-
-  it('unconfirms a confirmed meeting successfully', async () => {
-    let meeting, data;
-    try {
-      const meetingRes = await axios.post(constants.API_URI + '/meetings', {
-        author: mongoose.Types.ObjectId().toString(),
-        name: 'Test',
-        groupId: mongoose.Types.ObjectId().toString(),
-        startTime: '2020-05-19T13:30:00.000Z',
-        endTime: '2020-05-19T17:30:00.000Z',
-        confirmed: true,
-      });
-      meeting = meetingRes.data.data;
-
-      const response = await axios.post(
-        constants.API_URI + '/meeting/unconfirm/' + meeting._id
-      );
-      expect(response.data.data.confirmed).toBe(false);
-    } finally {
-      // Tear down
-      await axios.delete(
-        constants.API_URI + '/meeting/delete/' + meeting._id
+        `${constants.API_URI}/meeting/${meeting._id}`
       );
     }
   });

--- a/api/__tests__/user.test.js
+++ b/api/__tests__/user.test.js
@@ -4,16 +4,11 @@ const constants = require("./ignored/constants");
 const axios = require("axios").default;
 
 describe("/user/meetings/:userId", () => {
-  it("gets 404 status when invalid user is given", async () => {
-    try {
-      await axios.get(
-        `${constants.API_URI}/user/meetings/${constants.FAKE_OBJECT_ID}`
-      );
-      fail("No errors detected for the test request");
-    } catch (err) {
-      // Errors are expected
-      expect(err.response.status).toBe(404);
-    }
+  it("gets null data when invalid meeting is given", async () => {
+    const response = await axios.get(
+      `${constants.API_URI}/user/meetings/${constants.FAKE_OBJECT_ID}`
+    );
+    expect(response.data).toBeNull();
   });
 });
 

--- a/api/server/api-routes.js
+++ b/api/server/api-routes.js
@@ -202,8 +202,6 @@ router
 
 //// Meeting paths ////
 
-//// Meeting paths ////
-
 // Create a meeting
 router.route("/meeting/create").post(meetingController.create);
 

--- a/api/server/api-routes.js
+++ b/api/server/api-routes.js
@@ -205,19 +205,14 @@ router
 //// Meeting paths ////
 
 // Create a meeting
-router.route("/meetings").post(meetingController.create);
+router.route("/meeting/create").post(meetingController.create);
 
-// Delete a meeting
-router.route("/meeting/delete/:meetingId").delete(meetingController.delete);
-
-// Get all the details about a meeting
-router.route("/meeting/:meetingId").get(meetingController.view);
-
-// Confirm a meeting
-router.route("/meeting/confirm/:meetingId").post(meetingController.confirm);
-
-// Unconfirm a meeting
-router.route("/meeting/unconfirm/:meetingId").post(meetingController.unconfirm);
+// View, update, and delete a meeting
+router
+  .route("/meeting/:meetingId")
+  .get(meetingController.view)
+  .delete(meetingController.delete)
+  .patch(meetingController.update);
 
 // Export API routes
 module.exports = router;

--- a/api/server/controllers/meetingController.js
+++ b/api/server/controllers/meetingController.js
@@ -19,7 +19,7 @@ module.exports = {
    *  confirmed: Boolean (default: false) - whether the meeting is confirmed
    *
    * Returns:
-   *  500 if an internal server error occurs
+   *  An error message if an internal server error occurs
    *  The created meeting if the operation was successful
    */
   create: async (req, res) => {
@@ -41,7 +41,7 @@ module.exports = {
    *  meetingId: ObjectId - the meeting's ID
    *
    * Returns:
-   *  500 if an internal server error occurs
+   *  An error message if an internal server error occurs
    *  'null' if no meeting with the specified ID is found
    *  The deleted meeting if the operation was successful
    */
@@ -64,7 +64,7 @@ module.exports = {
    *  meetingId: ObjectId - the meeting's ID
    *
    * Returns:
-   *  500 if an internal server error occurs
+   *  An error message if an internal server error occurs
    *  'null' if no meeting with the specified ID is found
    *  The meeting's data if the operation was successful
    */
@@ -86,7 +86,7 @@ module.exports = {
    *  meetingId: ObjectId - the meeting's ID
    *
    * Returns:
-   *  500 if an internal server error occurs
+   *  An error message if an internal server error occurs
    *  'null' if no meeting with the specified ID is found
    *  The updated meeting if the operation was successful
    */

--- a/api/server/controllers/meetingController.js
+++ b/api/server/controllers/meetingController.js
@@ -31,7 +31,7 @@ module.exports = {
         errorName: err.name,
       })
     );
-    res.json(newMeeting);
+    res.status(200).json(newMeeting);
   },
 
   /*
@@ -76,7 +76,7 @@ module.exports = {
         errorName: err.name,
       })
     );
-    res.json(meeting);
+    res.status(200).json(meeting);
   },
 
   /*

--- a/api/server/controllers/meetingController.js
+++ b/api/server/controllers/meetingController.js
@@ -1,210 +1,109 @@
 // meetingController.js
 // Import meeting model
-Meeting = require("../models/meetingModel")
+Meeting = require("../models/meetingModel");
 // Import dependent models
-User = require("../models/userModel")
+User = require("../models/userModel");
 
-/*
- * Creates a new meeting.
- *
- * Required body parameters:
- *  author: ObjectId - the meeting's author
- *  name: String - the meeting's name
- *  groupId: ObjectId - the ID of the group that holds the meeting
- *  startTime: Date - the start time of the meeting
- *  endTime: Date - the end time of the meeting
- *
- * Optional body parameters:
- *  confirmed: Boolean (default: false) - whether the meeting is confirmed
- *
- * Returns:
- *  500 if an internal server error occurs
- *  The created meeting if the operation was successful
- */
-exports.create = function (req, res) {
-  const meeting = new Meeting();
-  meeting.author = req.body.author;
-  meeting.name = req.body.name;
-  meeting.groupID = req.body.groupId;
-  meeting.startTime = req.body.startTime;
-  meeting.endTime = req.body.endTime;
-  meeting.confirmed = req.body.confirmed ? req.body.confirmed : false;
-  meeting.save(function (err) {
-    if (err) {
+module.exports = {
+  /*
+   * Creates a new meeting.
+   *
+   * Required body parameters:
+   *  author: ObjectId - the meeting's author
+   *  name: String - the meeting's name
+   *  groupId: ObjectId - the ID of the group that holds the meeting
+   *  startTime: Date - the start time of the meeting
+   *  endTime: Date - the end time of the meeting
+   *
+   * Optional body parameters:
+   *  confirmed: Boolean (default: false) - whether the meeting is confirmed
+   *
+   * Returns:
+   *  500 if an internal server error occurs
+   *  The created meeting if the operation was successful
+   */
+  create: async (req, res) => {
+    req.body.confirmed = req.body.confirmed ? req.body.confirmed : false;
+    const newMeeting = await Meeting.create(req.body).catch((err) =>
       res.json({
         status: 500,
         errorMessage: err.message,
         errorName: err.name,
-      });
-    } else {
-      res.json({
-        status: res.statusCode,
-        message: "Meeting created successfully",
-        data: meeting,
-      });
-    }
-  });
-};
+      })
+    );
+    res.json(newMeeting);
+  },
 
-/*
- * Deletes a meeting.
- *
- * Required query parameters:
- *  meetingId: ObjectId - the meeting's ID
- *
- * Returns:
- *  500 if an internal server error occurs
- *  The deleted meeting if the operation was successful
- */
-exports.delete = function (req, res) {
-  Meeting.findByIdAndRemove(req.params.meetingId, function (err, meeting) {
-    if (err) {
+  /*
+   * Deletes a meeting.
+   *
+   * Required query parameters:
+   *  meetingId: ObjectId - the meeting's ID
+   *
+   * Returns:
+   *  500 if an internal server error occurs
+   *  'null' if no meeting with the specified ID is found
+   *  The deleted meeting if the operation was successful
+   */
+  delete: async (req, res) => {
+    const meeting = await Meeting.findByIdAndDelete(req.params.meetingId).catch(
+      (err) =>
+        res.json({
+          status: 500,
+          errorMessage: err.message,
+          errorName: err.name,
+        })
+    );
+    res.status(200).json(meeting);
+  },
+
+  /*
+   * Gets all the data about a meeting.
+   *
+   * Required query parameters:
+   *  meetingId: ObjectId - the meeting's ID
+   *
+   * Returns:
+   *  500 if an internal server error occurs
+   *  'null' if no meeting with the specified ID is found
+   *  The meeting's data if the operation was successful
+   */
+  view: async (req, res) => {
+    const meeting = await Meeting.findById(req.params.meetingId).catch((err) =>
       res.json({
         status: 500,
         errorMessage: err.message,
         errorName: err.name,
-      });
-    } else {
-      res.json({
-        status: res.statusCode,
-        data: meeting,
-      });
-    }
-  });
-};
+      })
+    );
+    res.json(meeting);
+  },
 
-/*
- * Gets all the data about a meeting.
- *
- * Required query parameters:
- *  meetingId: ObjectId - the meeting's ID
- *
- * Returns:
- *  500 if an internal server error occurs
- *  The meeting's data if the operation was successful
- */
-exports.view = function (req, res) {
-  Meeting.findById(req.params.meetingId, function (err, meeting) {
-    if (err) {
-      res.json({
-        status: 500,
-        errorMessage: err.message,
-        errorName: err.name,
-      });
-    } else {
-      res.json({
-        status: res.statusCode,
-        data: meeting,
-      });
-    }
-  });
-};
-
-/*
- * Confirms a meeting.
- *
- * Required query parameters:
- *  meetingId: ObjectId - the meeting's ID
- *
- * Returns:
- *  500 if an internal server error occurs
- *  404 if the meeting does not exist
- *  409 if the meeting is already confirmed
- *  The updated meeting's data if the operation was successful
- */
-exports.confirm = function (req, res) {
-  updateMeetingConfirmation(req, res, true);
-};
-
-/*
- * Unconfirms a meeting.
- *
- * Required query parameters:
- *  meetingId: ObjectId - the meeting's ID
- *
- * Returns:
- *  500 if an internal server error occurs
- *  404 if the meeting does not exist
- *  409 if the meeting is already not confirmed
- *  The updated meeting's data if the operation was successful
- */
-exports.unconfirm = function (req, res) {
-  updateMeetingConfirmation(req, res, false);
-};
-
-/*
- * Internal helper function
- *
- * Updates the confirmation flag for a meeting.
- *
- * Function parameters:
- *  req: the request received from client
- *  res: the response to be sent to client
- *  toConfirm - Boolean: 'true' for a confirming operation,
- *    or 'false for an unconfirming operation
- *
- * Required query parameters:
- *  meetingId: ObjectId - the meeting's ID
- *
- * Response will be updated with:
- *  500 if an internal server error occurs
- *  404 if the meeting does not exist
- *  409 if the meeting is already confirmed
- *  The updated meeting's data if the operation was successful
- */
-function updateMeetingConfirmation(req, res, toConfirm) {
-  Meeting.findById(req.params.meetingId, function (err, meeting) {
-    if (err) {
-      res.json({
-        status: 500,
-        errorMessage: err.message,
-        errorName: err.name,
-      });
-    } else if (meeting) {
-      const confirmed = meeting.confirmed;
-      if (confirmed === toConfirm) {
-        if (toConfirm) {
-          res.json({
-            status: 409,
-            message: "Meeting already confirmed",
-          });
-        } else {
-          res.json({
-            status: 409,
-            message: "Meeting already not confirmed",
-          });
-        }
-      } else {
-        meeting.confirmed = toConfirm;
-        meeting.save(function (err) {
-          if (err) {
-            res.json({
-              status: 500,
-              errorMessage: err.message,
-              errorName: err.name,
-            });
-          } else {
-            if (toConfirm) {
-              res.json({
-                status: res.statusCode,
-                message: "Meeting confirmed successfully",
-                data: meeting,
-              });
-            } else {
-              res.json({
-                status: res.statusCode,
-                message: "Meeting unconfirmed successfully",
-                data: meeting,
-              });
-            }
-          }
-        });
+  /*
+   * Updates a meeting with data included in the request body.
+   *
+   * Required query parameters:
+   *  meetingId: ObjectId - the meeting's ID
+   *
+   * Returns:
+   *  500 if an internal server error occurs
+   *  'null' if no meeting with the specified ID is found
+   *  The updated meeting if the operation was successful
+   */
+  update: async (req, res) => {
+    const meeting = await Meeting.findByIdAndUpdate(
+      req.params.meetingId,
+      req.body,
+      {
+        runValidators: true,
       }
-    } else {
+    ).catch((err) =>
       res.json({
-        status: 404,
-        message: "Meeting not exist",
-      });
-    }
-  });
-}
+        status: 500,
+        errorMessage: err.message,
+        errorName: err.name,
+      })
+    );
+    res.status(200).json(meeting);
+  },
+};

--- a/api/server/controllers/userController.js
+++ b/api/server/controllers/userController.js
@@ -170,7 +170,7 @@ module.exports = {
    *  userId: ObjectId - the ID of the user
    *
    * Returns:
-   *  500 if an internal server error occurs
+   *  An error message if an internal server error occurs
    *  'null' if no user with the specified ID is found
    *  The array of the user's meetings for the user if the operation was
    *    successful
@@ -196,7 +196,7 @@ module.exports = {
    *  meetingId: ObjectId - the ID of the meeting
    *
    * Returns:
-   *  500 if an internal server error occurs
+   *  An error message if an internal server error occurs
    *  Information about the user if the operation was successful
    */
   addMeeting: async (req, res) => {
@@ -220,7 +220,7 @@ module.exports = {
    *  meetingId: ObjectId - the ID of the meeting
    *
    * Returns:
-   *  500 if an internal server error occurs
+   *  An error message if an internal server error occurs
    *  Information about the user if the operation was successful
    */
   removeMeeting: async (req, res) => {

--- a/api/server/controllers/userController.js
+++ b/api/server/controllers/userController.js
@@ -171,22 +171,21 @@ module.exports = {
    *
    * Returns:
    *  500 if an internal server error occurs
-   *  404 if the user does not exist
+   *  'null' if no user with the specified ID is found
    *  The array of the user's meetings for the user if the operation was
    *    successful
    */
   userMeetings: async (req, res) => {
-    const user = await User.findById(req.params.userId).catch((err) =>
+    const userMeetings = await User.findById(req.params.userId, {
+      meetings: 1,
+    }).catch((err) =>
       res.json({
         status: 500,
         errorMessage: err.message,
         errorName: err.name,
       })
     );
-    if (!user) {
-      return res.status(404).send("User not found");
-    }
-    res.status(200).json(user.meetings);
+    res.status(200).json(userMeetings);
   },
 
   /*

--- a/api/server/models/meetingModel.js
+++ b/api/server/models/meetingModel.js
@@ -3,9 +3,9 @@ var mongoose = require("mongoose");
 var meetingSchema = mongoose.Schema({
   author: mongoose.Types.ObjectId, //UserID
   name: String,
-  groupID: mongoose.Types.ObjectId,
-  startTime: Date,
-  endTime: Date,
+  group: mongoose.Types.ObjectId,
+  start: Date,
+  end: Date,
   confirmed: Boolean,
 });
 


### PR DESCRIPTION
These changes update the meeting models and controllers I wrote before so that they are consistent with other back-end components in code style and endpoint style:
- Define all API functions in the `module.exports` object instead of multiple variables like `exports.create` and `exports.delete`
- Replace `/meetings` with `/meeting/create` for meeting creation route, and use a unified `/meeting/:meetingId` route for getting, updating and deleting a meeting

### Incompatible API Changes
- `POST /meetings` is changed to `POST /meeting/create`
- `DELETE /meeting/delete/:meetingId` is changed to `DELETE /meeting/:meetingId`
- `/meeting/confirm/:meetingId` is removed; use `PATCH /meeting/:meetingId` instead
- `/meeting/unconfirm/:meetingId` is removed; use `PATCH /meeting/:meetingId` instead

If you have any code that uses any of those endpoints, please remember to update it after this is merged.